### PR TITLE
geom_alt props

### DIFF
--- a/data/421/167/889/421167889.geojson
+++ b/data/421/167/889/421167889.geojson
@@ -658,6 +658,9 @@
     },
     "wof:country":"TM",
     "wof:created":1459008746,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c8029af6ee24b08c9a8173af545fa4c",
     "wof:hierarchy":[
         {
@@ -668,7 +671,7 @@
         }
     ],
     "wof:id":421167889,
-    "wof:lastmodified":1566667074,
+    "wof:lastmodified":1582319625,
     "wof:name":"Ashgabat",
     "wof:parent_id":85678925,
     "wof:placetype":"locality",

--- a/data/856/326/71/85632671.geojson
+++ b/data/856/326/71/85632671.geojson
@@ -981,6 +981,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -1037,6 +1038,11 @@
     },
     "wof:country":"TM",
     "wof:country_alpha3":"TKM",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"84822db1b4d4e898c7ceda8a417a608c",
     "wof:hierarchy":[
         {
@@ -1051,7 +1057,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1566667001,
+    "wof:lastmodified":1582319622,
     "wof:name":"Turkmenistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/326/71/85632671.geojson
+++ b/data/856/326/71/85632671.geojson
@@ -981,7 +981,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -1057,7 +1056,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1582319622,
+    "wof:lastmodified":1583206372,
     "wof:name":"Turkmenistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.