### PR TITLE
tm concordances, placetype local, and more

### DIFF
--- a/data/856/326/71/85632671.geojson
+++ b/data/856/326/71/85632671.geojson
@@ -1224,6 +1224,7 @@
         "hasc:id":"TM",
         "icao:code":"EZ",
         "ioc:id":"TKM",
+        "iso:code":"TM",
         "itu:id":"TKM",
         "loc:id":"n91129790",
         "m49:code":"795",
@@ -1238,6 +1239,7 @@
         "wk:page":"Turkmenistan",
         "wmo:id":"TR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TM",
     "wof:country_alpha3":"TKM",
     "wof:geom_alt":[
@@ -1259,7 +1261,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1694639516,
+    "wof:lastmodified":1695881171,
     "wof:name":"Turkmenistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/789/23/85678923.geojson
+++ b/data/856/789/23/85678923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.476071,
-    "geom:area_square_m":118507082129.065536,
+    "geom:area_square_m":118507080552.212524,
     "geom:bbox":"52.437671,37.323744,57.165224,42.345401",
     "geom:latitude":39.796492,
     "geom:longitude":55.017935,
@@ -347,14 +347,16 @@
         "gn:id":162152,
         "gp:id":2347349,
         "hasc:id":"TM.BA",
+        "iso:code":"TM-B",
         "iso:id":"TM-B",
         "qs_pg:id":895005,
         "unlc:id":"TM-B",
         "wd:id":"Q486073",
         "wk:page":"Balkan Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TM",
-    "wof:geomhash":"c1da0b5be9b5e033f961aee8d840ef40",
+    "wof:geomhash":"d641fc3cccc7cef53b010139a93ddb54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1690874644,
+    "wof:lastmodified":1695884328,
     "wof:name":"Balkan",
     "wof:parent_id":85632671,
     "wof:placetype":"region",

--- a/data/856/789/25/85678925.geojson
+++ b/data/856/789/25/85678925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.385342,
-    "geom:area_square_m":100432904355.597885,
+    "geom:area_square_m":100432906020.836441,
     "geom:bbox":"56.571049,35.545891,61.596478,40.214187",
     "geom:latitude":38.536054,
     "geom:longitude":59.118299,
@@ -362,14 +362,16 @@
         "gn:id":162181,
         "gp:id":2347347,
         "hasc:id":"TM.AL",
+        "iso:code":"TM-A",
         "iso:id":"TM-A",
         "qs_pg:id":890108,
         "unlc:id":"TM-A",
         "wd:id":"Q399899",
         "wk:page":"Ahal Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TM",
-    "wof:geomhash":"ead51eeb010abcaeb41c063f37f8751d",
+    "wof:geomhash":"cb2da73593644ad0004b125aa957b8c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1690874645,
+    "wof:lastmodified":1695884838,
     "wof:name":"Ahal",
     "wof:parent_id":85632671,
     "wof:placetype":"region",

--- a/data/856/789/31/85678931.geojson
+++ b/data/856/789/31/85678931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.852151,
-    "geom:area_square_m":73092774723.426361,
+    "geom:area_square_m":73092773699.423416,
     "geom:bbox":"56.533721,39.473612,61.004318,42.791188",
     "geom:latitude":41.160826,
     "geom:longitude":58.70963,
@@ -304,13 +304,15 @@
         "gn:id":601465,
         "gp:id":2347351,
         "hasc:id":"TM.DA",
+        "iso:code":"TM-D",
         "iso:id":"TM-D",
         "qs_pg:id":890110,
         "wd:id":"Q487393",
         "wk:page":"Da\u015foguz Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TM",
-    "wof:geomhash":"633446629274c2234f67b4392f3761fc",
+    "wof:geomhash":"aa37f154a70c5e036ac5fcec043b81f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1690874644,
+    "wof:lastmodified":1695884328,
     "wof:name":"Tashauz",
     "wof:parent_id":85632671,
     "wof:placetype":"region",

--- a/data/856/789/37/85678937.geojson
+++ b/data/856/789/37/85678937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.690471,
-    "geom:area_square_m":93231905272.890045,
+    "geom:area_square_m":93231912785.248917,
     "geom:bbox":"60.247517,36.849586,66.645782,41.300323",
     "geom:latitude":38.905103,
     "geom:longitude":63.175504,
@@ -311,13 +311,15 @@
         "gn:id":1219651,
         "gp:id":2347348,
         "hasc:id":"TM.LE",
+        "iso:code":"TM-L",
         "iso:id":"TM-L",
         "qs_pg:id":1354698,
         "wd:id":"Q487389",
         "wk:page":"Lebap Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TM",
-    "wof:geomhash":"42b082caa2862c76f43d2bf5566c9b13",
+    "wof:geomhash":"58b6206cacd80a9c926b21cef950f540",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1690874644,
+    "wof:lastmodified":1695884838,
     "wof:name":"Chardzhou",
     "wof:parent_id":85632671,
     "wof:placetype":"region",

--- a/data/856/789/41/85678941.geojson
+++ b/data/856/789/41/85678941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.655261,
-    "geom:area_square_m":85216926396.337814,
+    "geom:area_square_m":85216925700.225479,
     "geom:bbox":"60.459493,35.140647,64.728549,39.513971",
     "geom:latitude":37.211636,
     "geom:longitude":62.317491,
@@ -346,14 +346,16 @@
         "gn:id":1218666,
         "gp:id":2347350,
         "hasc:id":"TM.MA",
+        "iso:code":"TM-M",
         "iso:id":"TM-M",
         "qs_pg:id":890109,
         "unlc:id":"TM-M",
         "wd:id":"Q487401",
         "wk:page":"Mary Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TM",
-    "wof:geomhash":"94a7c058ba173b23d4bd6d4a3bac2842",
+    "wof:geomhash":"6c6a38899e7f3b6c50fe318b256860c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -368,7 +370,7 @@
     "wof:lang_x_spoken":[
         "tuk"
     ],
-    "wof:lastmodified":1690874644,
+    "wof:lastmodified":1695884838,
     "wof:name":"Mary",
     "wof:parent_id":85632671,
     "wof:placetype":"region",

--- a/data/890/435/653/890435653.geojson
+++ b/data/890/435/653/890435653.geojson
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":890435653,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886528,
     "wof:name":"A\u015fgabat \u015e\u00e4heri",
     "wof:parent_id":85678925,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.